### PR TITLE
Add authorizekey block

### DIFF
--- a/authorizekey/authorizekey.json
+++ b/authorizekey/authorizekey.json
@@ -3,12 +3,12 @@
 	"text": "Add public SSH key for user authentication: %1",
 	"script": "authorizekey.py",
     "args": [
-		{
-			"type": "text",
-			"default": "ssh-rsa ...",
-			"maxLength": 0
-		}
-	],
+        {
+            "type": "text",
+            "default": "ssh-rsa ...",
+            "maxLength": 0
+        }
+    ],
 	"network": false,
 	"continue": true,
 	"type": "setting",

--- a/authorizekey/authorizekey.json
+++ b/authorizekey/authorizekey.json
@@ -1,11 +1,11 @@
 {
 	"name": "authorizekey",
-	"text": "Add public SSH key for user authentication",
+	"text": "Add public SSH key for user authentication: %1",
 	"script": "authorizekey.py",
     "args": [
 		{
 			"type": "text",
-			"default": "",
+			"default": "ssh-rsa ...",
 			"maxLength": 0
 		}
 	],
@@ -18,5 +18,5 @@
 		"raspbian-lite-pibakery.img"
 	],
 	"shortDescription":"Add public SSH key for user authentication.",
-	"longDescription":"The secure shell (SSH) service supports public key authentication. This authorizes the owner of the specified public key to login without entering a password."
+	"longDescription":"The secure shell (SSH) service supports public key authentication. This authorizes the owner of the specified public key to login without entering a password. Paste the contents of your RSA or DSA public key file (e.g.,  ~/.ssh/id_rsa.pub on a Mac or Linux computer) into the text box."
 }

--- a/authorizekey/authorizekey.json
+++ b/authorizekey/authorizekey.json
@@ -1,0 +1,22 @@
+{
+	"name": "authorizekey",
+	"text": "Add public SSH key for user authentication",
+	"script": "authorizekey.py",
+    "args": [
+		{
+			"type": "text",
+			"default": "",
+			"maxLength": 0
+		}
+	],
+	"network": false,
+	"continue": true,
+	"type": "setting",
+	"category":"setting",
+	"supportedOperatingSystems": [
+		"raspbian-pibakery.img",
+		"raspbian-lite-pibakery.img"
+	],
+	"shortDescription":"Add public SSH key for user authentication.",
+	"longDescription":"The secure shell (SSH) service supports public key authentication. This authorizes the owner of the specified public key to login without entering a password."
+}

--- a/authorizekey/authorizekey.py
+++ b/authorizekey/authorizekey.py
@@ -23,7 +23,7 @@ try:
     # Append the public key to authorized_keys, creating the
     # file if necessary.
     with open('authorized_keys', 'a') as f:
-        f.write(sys.argv[1])
+        f.write(sys.argv[1] + '\n')
         f.close()
 
     # Ensure that authorized_keys is rw for owner but nobody else.

--- a/authorizekey/authorizekey.py
+++ b/authorizekey/authorizekey.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+
+import sys
+import os.path
+import stat
+
+public_key = sys.argv[1]
+
+try:
+    # Start at the user's $HOME directory.
+    os.chdir(os.environ['HOME'])
+
+    # Create a new .ssh directory, if necessary.
+    if not os.path.exists('.ssh'):
+        os.path.mkdir('.ssh')
+
+    # Ensure that .ssh/ is rwx for owner but nobody else.
+    os.chmod('.ssh', stat.S_IRWXU)
+
+    # Enter .ssh/
+    os.chdir('.ssh')
+
+    # Append the public key to authorized_keys, creating the
+    # file if necessary.
+    with open('authorized_keys', 'a') as f:
+        f.write(sys.argv[1])
+        f.close()
+
+    # Ensure that authorized_keys is rw for owner but nobody else.
+    os.chmod('authorized_keys', stat.S_IRUSR | stat.S_IWUSR)
+
+except Exception as e:
+    print e
+    return 1

--- a/authorizekey/authorizekey.py
+++ b/authorizekey/authorizekey.py
@@ -31,4 +31,4 @@ try:
 
 except Exception as e:
     print e
-    return 1
+    sys.exit(1)

--- a/authorizekey/authorizekey.py
+++ b/authorizekey/authorizekey.py
@@ -12,7 +12,7 @@ try:
 
     # Create a new .ssh directory, if necessary.
     if not os.path.exists('.ssh'):
-        os.path.mkdir('.ssh')
+        os.mkdir('.ssh')
 
     # Ensure that .ssh/ is rwx for owner but nobody else.
     os.chmod('.ssh', stat.S_IRWXU)


### PR DESCRIPTION
Authorizes a single public ssh key by appending it to ~/.ssh/authorized_keys, creating the path and setting permissions as needed.

Fixes davidferguson/pibakery-blocks#14