### PR TITLE
Wait for network

### DIFF
--- a/waitfornetwork/waitfornetwork.json
+++ b/waitfornetwork/waitfornetwork.json
@@ -5,7 +5,7 @@
 	"args": [
 		{
 			"type": "menu",
-			"options": ["yes", "no"]
+			"options": ["Yes", "No"]
 		}
 	],
 	"network": false,
@@ -17,5 +17,5 @@
 		"raspbian-lite-pibakery.img"
 	],
 	"shortDescription":"Change Wait for Network setting",
-	"longDescription":"By default, the pi will not wait for a network connection when booting. You may want to enable this setting if you rely on network mounted drives"
+	"longDescription":"By default, the pi will not wait for a network connection when booting. You may want to enable this setting if you rely on network mounted drives, or other network services."
 }

--- a/waitfornetwork/waitfornetwork.json
+++ b/waitfornetwork/waitfornetwork.json
@@ -1,0 +1,21 @@
+{
+	"name": "waitfornetwork",
+	"text": "Wait for network on boot? %1",
+	"script": "waitfornetwork.sh",
+	"args": [
+		{
+			"type": "menu",
+			"options": ["yes", "no"]
+		}
+	],
+	"network": false,
+	"continue": true,
+	"type": "setting",
+	"category":"setting",
+	"supportedOperatingSystems": [
+		"raspbian-pibakery.img",
+		"raspbian-lite-pibakery.img"
+	],
+	"shortDescription":"Change Wait for Network setting",
+	"longDescription":"By default, the pi will not wait for a network connection when booting. You may want to enable this setting if you rely on network mounted drives"
+}

--- a/waitfornetwork/waitfornetwork.sh
+++ b/waitfornetwork/waitfornetwork.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+VAL=1
+if [ $1 == "yes" ]; then
+VAL=0
+fi
+raspi-config nonint do_boot_wait $VAL

--- a/waitfornetwork/waitfornetwork.sh
+++ b/waitfornetwork/waitfornetwork.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 VAL=1
-if [ $1 == "yes" ]; then
+if [ $1 == "Yes" ]; then
 VAL=0
 fi
 raspi-config nonint do_boot_wait $VAL


### PR DESCRIPTION
This block allows the user to set the `Wait for Network` configuration value. This is helpful for handling network mounted drives.