### PR TITLE
Add block to mount network share

### DIFF
--- a/mountnetworkshare/mountnetworkshare.json
+++ b/mountnetworkshare/mountnetworkshare.json
@@ -1,0 +1,21 @@
+{
+	"name": "mountnetworkshare",
+	"text": "Mount network share\\n%1\\nto\\n%2",
+	"script": "mountnetworkshare.sh",
+	"args": [
+		{
+			"type": "text",
+			"default": "server:/share"
+		},
+		{
+			"type": "text",
+			"default": "/mount/share"
+		}
+	],
+	"network": true,
+	"continue": true,
+	"type": "network",
+	"category":"network",
+	"shortDescription":"Mount a network share",
+	"longDescription":"Mount a network share"
+}

--- a/mountnetworkshare/mountnetworkshare.sh
+++ b/mountnetworkshare/mountnetworkshare.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+service rpcbind start
+mkdir -p $2
+mount $1 $2


### PR DESCRIPTION
This block mounts a network share. It also runs the command `service rpcbind start` because rpcbind is not enabled by default on raspbian.