### PR TITLE
Rpi-update

### DIFF
--- a/rpiupdate/rpiupdate.json
+++ b/rpiupdate/rpiupdate.json
@@ -1,6 +1,6 @@
 {
 	"name": "rpiupdate",
-	"text": "Update the Raspberry Pi kernel.",
+	"text": "Update the Raspberry Pi kernel.\\nRequires internet connection.\\nRequires restart.",
 	"script": "rpiupdate.sh",
 	"network": true,
 	"continue": true,

--- a/rpiupdate/rpiupdate.json
+++ b/rpiupdate/rpiupdate.json
@@ -1,0 +1,16 @@
+{
+	"name": "rpiupdate",
+	"text": "Update the Raspberry Pi kernel.",
+	"script": "rpiupdate.sh",
+	"network": true,
+	"continue": true,
+	"type": "other",
+	"category": "other",
+	"supportedOperatingSystems": [
+		"raspbian-pibakery.img",
+		"raspbian-lite-pibakery.img"
+	],
+	"shortDescription":"Updates the RPI kernel using the rpi-update utility. Requires networking. Requires reboot.",
+	"longDescription":"Updates the Raspberry Pi kernel, using the rpi-update utility. Depending on network and type of RPI, this will take some time to complete. This block requires networking. Requires reboot to take effect.",
+	"args": [ ]
+}

--- a/rpiupdate/rpiupdate.sh
+++ b/rpiupdate/rpiupdate.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+# First try to install rpi-update, as it doesn't exist on raspbian lite
+apt-get update
+DEBIAN_FRONTEND=noninteractive apt-get -y install rpi-update
+
 SKIP_WARNING=1 rpi-update

--- a/rpiupdate/rpiupdate.sh
+++ b/rpiupdate/rpiupdate.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+SKIP_WARNING=1 rpi-update


### PR DESCRIPTION
Small block to allow running rpi-update.  Also includes apt-get install for rpi-update in for raspbian-lite that doesn't include it.  This block requires networking and a reboot to take effect.