### PR TITLE
Removes the # at the beginning of the framewidth and frameheight line…

### DIFF
--- a/vncframesize/vncframesize.json
+++ b/vncframesize/vncframesize.json
@@ -1,0 +1,16 @@
+{
+	"name": "vncframesize",
+	"text": "VNC Framesize",
+	"script": "vncframesize.sh",
+	"args": [],
+	"network": false,
+	"continue": true,
+	"type": "other",
+	"category":"other",
+	"supportedOperatingSystems": [
+		"raspbian-pibakery.img",
+		"raspbian-lite-pibakery.img"
+	],
+	"shortDescription":"Change frame size to 1280x720.",
+	"longDescription":"This block simpley un-comments the framesize lines in /boot/config.txt which gives 1280x720 instead of the default 640x480 which can be better for headless VNC sessions."
+}

--- a/vncframesize/vncframesize.sh
+++ b/vncframesize/vncframesize.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+if sudo grep "#framebuffer_width=1280" /boot/config.txt
+then
+        sudo sed -i "s/#framebuffer_width=1280/framebuffer_width=1280/g" /boot/config.txt
+fi
+if sudo grep "#framebuffer_height=720" /boot/config.txt
+then
+        sudo sed -i "s/#framebuffer_height=720/framebuffer_height=720/g" /boot/config.txt
+fi
+
+exit


### PR DESCRIPTION
…s in /boot/config.txt

This allows better VNC screen resolution if this block included in 1st boot and followed by reboot