### PR TITLE
New block: expandrootfs

### DIFF
--- a/expandrootfs/expandrootfs.json
+++ b/expandrootfs/expandrootfs.json
@@ -1,0 +1,15 @@
+{
+	"name": "expandrootfs",
+	"text": "Expand Filesystem \\nRequires restart to take effect",
+	"script": "expandrootfs.sh",
+	"network": false,
+	"continue": true,
+	"type": "setting",
+	"category": "setting",
+	"supportedOperatingSystems": [
+		"raspbian-pibakery.img",
+		"raspbian-lite-pibakery.img"
+	],
+	"shortDescription":"Expand Filesystem. Requires reboot to take effect.",
+	"longDescription":"Expand Filesystem. Ensures that all of the SD card storage is available to the OS. Requires reboot to take effect.",
+}

--- a/expandrootfs/expandrootfs.sh
+++ b/expandrootfs/expandrootfs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+raspi-config nonint do_expand_rootfs


### PR DESCRIPTION
This block allows you to expand Filesystem. Ensures that all of the SD card storage is available to the OS. Requires reboot to take effect.