### PR TITLE
added setssh

### DIFF
--- a/setssh/setssh.json
+++ b/setssh/setssh.json
@@ -1,0 +1,21 @@
+{
+	"name": "setssh",
+	"text": "%1 SSH server",
+	"script": "setssh.sh",
+	"args": [
+		{
+			"type": "menu",
+			"options": ["Enable", "Disable"]
+		}
+	],
+	"network": false,
+	"continue": true,
+	"type": "setting",
+	"category":"setting",
+	"supportedOperatingSystems": [
+		"raspbian-pibakery.img",
+		"raspbian-lite-pibakery.img"
+	],
+	"shortDescription":"Enable or disable ssh server to allow for SSH login",
+	"longDescription":"By default Raspbian does not allow for SSH access and this must be enabled for ssh logins to work."
+}

--- a/setssh/setssh.sh
+++ b/setssh/setssh.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "$1" == "Enable" ]
+then
+  raspi-config nonint do_ssh 0
+else
+  raspi-config nonint do_ssh 1
+fi


### PR DESCRIPTION
ssh block to enable or disable the SSH server from running on first boot.  Since raspbian disables the ssh server, I wanted a way to turn this on via the startup script.

This is my first pull request to this repo - so I am open to any and all comments.

Thank you