### PR TITLE
Fix block name bug in updateupgrade

### DIFF
--- a/updateupgrade/updateupgrade.json
+++ b/updateupgrade/updateupgrade.json
@@ -1,5 +1,5 @@
 {
-	"name": "packageupgrade",
+	"name": "updateupgrade",
 	"text": "Upgrade all installed packages\\nRequires internet connection.",
 	"script": "updateupgrade.sh",
 	"args": [],


### PR DESCRIPTION
Name was set to packageupgrade, but the dir/block name is actually updateupgrade, so it would fail on writing blocks. Fixed by setting name to updateupgrade.