### PR TITLE
Added new 'copyfile' block to copy/move files and directories

### DIFF
--- a/copyfile/copyfile.json
+++ b/copyfile/copyfile.json
@@ -1,0 +1,25 @@
+{
+  "name": "copyfile",
+  "text": "CopyFile\\nCopy or move things around on the local filesystem\\nCopy %1\\nto %2\\nOperation type: %3",
+  "script": "copyfile.py",
+  "network": false,
+  "continue": true,
+  "type": "other",
+  "category": "other",
+  "shortDescription": "Copy or move things around on the local filesystem.",
+  "longDescription": "Copy or move files or directories around on the local filesystem.  The first argument is the source, the second is the destination. Copying a file creates or overwrites the destination, while leaving the source file as-is.  If you elect to move a file, then the destination will still be created or overwritten, but the original will no longer exist. Source and dest may be directory names as well, and will operate with the same symantics as the Unix cp/mv commands.",
+  "args": [
+    {
+      "type": "text",
+      "default": "/home/pi/.bashrc"
+    },
+    {
+      "type": "text",
+      "default": "/home/pi/.bashrc.orig"
+    },
+    {
+      "type": "menu",
+      "options": ["Copy", "Move"]
+    }
+  ]
+}

--- a/copyfile/copyfile.py
+++ b/copyfile/copyfile.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+
+import shutil
+import sys
+
+source = sys.argv[1]
+dest = sys.argv[2]
+optype = sys.argv[3]
+
+if optype == "Copy":
+    shutil.copy2(source, dest)
+elif optype == "Move":
+    shutil.move(source, dest)


### PR DESCRIPTION
This creates a new "copyfile" block under the "Other" category.  It allows you to either copy or move files/directories around on the local filesystem.  In general, this block exhibits the same behavior that Unix cp and mv commands do with respect to having directories in the source and/or destination fields (e.g., moving a file into a directory works as expected, as does copying a directory into a directory).
