### PR TITLE
Fix order of operations for wificonnect.py

### DIFF
--- a/wifisetup/wifiConnect.py
+++ b/wifisetup/wifiConnect.py
@@ -41,12 +41,11 @@ if wifiSSID != "" and wifiType != "":
 	elif wifiType == "WPA/WPA2":
 		wifiText = wpaWifi.replace("WIFI-SSID", wifiSSID).replace("WIFI-PSK", wifiPSK)
 
-with open("/etc/wpa_supplicant/wpa_supplicant.conf", "a") as wifiFile:
-	wifiFile.write(wifiText)
-
-
 # raspbian 2018-03-14 now requires us to have the country= line.
 os.system('raspi-config nonint do_wifi_country "' + countryCode + '"')
+
+with open("/etc/wpa_supplicant/wpa_supplicant.conf", "a") as wifiFile:
+	wifiFile.write(wifiText)
 
 os.system("wpa_cli reconfigure")
 time.sleep(5)


### PR DESCRIPTION
It appears that when the country code is set, it resets the wpa_supplicant.conf. This moves the country
code ahead of appending the files with the wifi SSD information.