### PR TITLE
New block: change keyboard layout

### DIFF
--- a/changekeyboardlayout/changeKeyboardLayout.py
+++ b/changekeyboardlayout/changeKeyboardLayout.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+import sys
+
+filename = "/etc/default/keyboard"
+
+model = sys.argv[1]
+layout = sys.argv[2]
+variant = sys.argv[3]
+options = sys.argv[4]
+
+text = ""
+
+# read the text in the file
+with open(filename) as f:
+    line = f.readline()
+
+# replace the lines in the file with the desired settings
+    while line:
+       print line.strip()
+       if line.find('XKBMODEL') > -1:
+         line = "XKBMODEL=\""+model+"\"\n"
+       elif line.find('XKBLAYOUT') > -1:
+         line = "XKBLAYOUT=\""+layout+"\"\n"
+       elif line.find('XKBVARIANT') > -1:
+         line = "XKBVARIANT=\""+variant+"\"\n"
+       elif line.find('XKBOPTIONS') > -1:
+         line = "XKBOPTIONS=\""+options+"\"\n"
+
+       text = text + line
+       line = f.readline()
+
+# write the changed text back to the file
+with open(filename, "w") as f:
+    f.write(text)

--- a/changekeyboardlayout/changekeyboardlayout.json
+++ b/changekeyboardlayout/changekeyboardlayout.json
@@ -1,0 +1,37 @@
+{
+	"name": "changekeyboardlayout",
+	"text": "Change Keyboard Layout\\nModel: %1\\nLayout: %2\\nVariant: %3\\nOptions: %4",
+	"script": "changeKeyboardLayout.py",
+	"args": [
+		{
+			"type": "text",
+			"default": "pc105",
+			"maxLength":0
+		},
+		{
+			"type": "text",
+			"default": "us",
+			"maxLength":0
+		},
+		{
+			"type": "text",
+			"default": "",
+			"maxLength":0
+		},
+		{
+			"type": "text",
+			"default": "",
+			"maxLength":0
+		}
+	],
+	"network": false,
+	"continue": true,
+	"type": "setting",
+	"category":"setting",
+	"supportedOperatingSystems": [
+		"raspbian-pibakery.img",
+		"raspbian-lite-pibakery.img"
+	],
+	"shortDescription":"Setup the desired keyboard layout.",
+	"longDescription":"This block allows you to change the keyboard layout. For more informations about the variables check: https://manpages.debian.org/buster/keyboard-configuration/keyboard.5.en.html"
+}


### PR DESCRIPTION
With this block the keyboard layout can be changed from the first boot. The correct settings for your keyboard can be found here: https://manpages.debian.org/buster/keyboard-configuration/keyboard.5.en.html