### PR TITLE
New block: setup eduroam wifi

### DIFF
--- a/eduroamwifisetup/eduroamWifiConnect.py
+++ b/eduroamwifisetup/eduroamWifiConnect.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+import sys, os, time
+
+networkText = """
+
+network={
+          ssid="eduroam"
+          scan_ssid=1
+          key_mgmt=WPA-EAP
+          eap=PEAP
+          identity="username"
+          password="userpassword"
+          phase1="peaplabel=0"
+          phase2="auth=MSCHAPV2"
+          priority=1
+}
+"""
+
+userName = sys.argv[1]
+userPassword = sys.argv[2]
+countryCode = sys.argv[3]
+
+if userName != "" and userPassword != "":
+    networkText = networkText.replace("username", userName)
+    networkText = networkText.replace("userpassword", userPassword)
+
+# raspbian 2018-03-14 now requires us to have the country= line.
+os.system('raspi-config nonint do_wifi_country "' + countryCode + '"')
+
+with open("/etc/wpa_supplicant/wpa_supplicant.conf", "a") as wifiFile:
+	wifiFile.write(networkText)
+
+os.system("wpa_cli reconfigure")
+time.sleep(5)
+os.system("systemctl daemon-reload")
+time.sleep(5)
+os.system("systemctl restart dhcpcd")
+time.sleep(5)
+
+if sys.argv[4] == "Yes":
+    # It's likely that the block following this one will be one that uses the
+    # internet - such as a download file or apt-get block. It takes a few seconds
+    # for the WiFi to connect and obtain an IP address, run the waitForNetwork shell
+    # script, which will loop waiting for a network connection (timeout 150 seconds)
+    # and continue once there is one
+    os.system("chmod +x /boot/PiBakery/blocks/eduroamwifisetup/waitForNetwork.sh")
+    os.system("/boot/PiBakery/blocks/eduroamwifisetup/waitForNetwork.sh")

--- a/eduroamwifisetup/eduroamwifisetup.json
+++ b/eduroamwifisetup/eduroamwifisetup.json
@@ -1,0 +1,36 @@
+{
+	"name": "eduroamwifisetup",
+	"text": "Setup Eduroam WiFi\\nUser Identity: %1\\nPassword: %2\\nCountry (ISO 3166):%3\\nWait for Network:%4",
+	"script": "eduroamWifiConnect.py",
+	"args": [
+		{
+			"type": "text",
+			"default": "user-identity",
+			"maxLength":0
+		},
+		{
+			"type": "text",
+			"default": "password",
+			"maxLength":0
+		},
+		{
+			"type": "text",
+			"default": "GB",
+			"maxLength":0
+		},
+		{
+			"type": "menu",
+			"options": ["Yes", "No"]
+		}
+	],
+	"network": false,
+	"continue": true,
+	"type": "network",
+	"category":"network",
+	"supportedOperatingSystems": [
+		"raspbian-pibakery.img",
+		"raspbian-lite-pibakery.img"
+	],
+	"shortDescription":"Automatically connect to a eduroam WiFi network.",
+	"longDescription":"This block allows you to enter a eduroam username and password, and then your Raspberry Pi will automatically connect to that network when it is first switched on."
+}

--- a/eduroamwifisetup/waitForNetwork.sh
+++ b/eduroamwifisetup/waitForNetwork.sh
@@ -1,0 +1,3 @@
+ #!/bin/bash
+
+for i in {1..50}; do ping -c1 8.8.8.8 &> /dev/null && break; done


### PR DESCRIPTION
This blocks adds automatically the WIFI settings for eduroam networks which are used at universities all over the world.
You only need to provide your username, your password and the countrycode

Note: The password will not be encrypted and is stored in plain text on the Raspberry Pi, as it is also in the regular WIFI block!!